### PR TITLE
[Feature] Language Feature - Auto Conversion

### DIFF
--- a/Parcel.NExT/CoreEngines/Parcel.CoreEngine/Helpers/TypeHelper.cs
+++ b/Parcel.NExT/CoreEngines/Parcel.CoreEngine/Helpers/TypeHelper.cs
@@ -1,7 +1,11 @@
-﻿namespace Parcel.CoreEngine.Helpers
+﻿using Parcel.Infrastructure;
+using System.ComponentModel;
+
+namespace Parcel.CoreEngine.Helpers
 {
     public static class TypeHelper
     {
+        #region Type Calssification
         /// <summary>
         /// Check whether a type can represent number, which is parcel defaults to double
         /// </summary>
@@ -34,5 +38,71 @@
                     return false;
             }
         }
+        #endregion
+
+
+        #region Type Conversion
+        public static bool CanConvert(object instance, Type to)
+            => CanConvert(instance.GetType(), to);
+        public static bool CanConvert(Type from, Type to)
+        {
+            if (TypeDescriptor.GetConverter(from).CanConvertTo(to)) // Requires IConvertible; This doesn't cover everything
+                return true;
+            else if (from == typeof(string) && (IsNumericalType(to) || typeof(IParcelSerializable).IsAssignableFrom(to)))
+                return true;
+            else if (to == typeof(string))
+                return true;
+            else if (to.GetConstructor([from]) != null) // Check constructor
+                return true;
+            else if (to.GetMethod("op_Implicit", [from]) != null || from.GetMethod("op_Implicit", [from])?.ReturnType == to) // Check implicitor converter
+                return true;
+            return false;
+        }
+        public static bool TryConvert(object instance, Type to, out object? result)
+        {
+            Type from = instance.GetType();
+            if (TypeDescriptor.GetConverter(from).CanConvertTo(to)) // This doesn't cover everything
+            {
+                result = Convert.ChangeType(instance, to);
+                return true;
+            }
+            // TODO: Handling string to IParcelSerializable conversion
+            // TODO: Handle IParcelSerializable to string conversion
+            else if (from == typeof(string) && IsNumericalType(to))
+            {
+                TypeConverter typeConverter = TypeDescriptor.GetConverter(to);
+                result = typeConverter.ConvertFromString((string)instance);
+                return true;
+            }
+            else
+            {
+                // Check constructor
+                System.Reflection.ConstructorInfo? constructor = to.GetConstructor([from]);
+                if (constructor != null) 
+                {
+                    result = constructor?.Invoke([instance]);
+                    return true;
+                }
+
+                // Check to implicit constructor
+                System.Reflection.MethodInfo? toImplicit = to.GetMethod("op_Implicit", [from]);
+                System.Reflection.MethodInfo? fromImplicit = from.GetMethod("op_Implicit", [from]);
+                if (toImplicit != null)
+                {
+                    result = toImplicit.Invoke(null, [instance]);
+                    return true;
+                }
+                if (fromImplicit != null && fromImplicit.ReturnType == to)
+                {
+                    result = fromImplicit.Invoke(null, [instance]);
+                    return true;
+                }
+            }
+
+            // No conversion available
+            result = null;
+            return false;
+        }
+        #endregion
     }
 }

--- a/Parcel.NExT/CoreEngines/Parcel.NExT.Interpreter/Types/FunctionalNodeDescription.cs
+++ b/Parcel.NExT/CoreEngines/Parcel.NExT.Interpreter/Types/FunctionalNodeDescription.cs
@@ -1,4 +1,5 @@
-﻿using Parcel.NExT.Interpreter.Types;
+﻿using Parcel.CoreEngine.Helpers;
+using Parcel.NExT.Interpreter.Types;
 using System.ComponentModel;
 using System.Reflection;
 
@@ -57,8 +58,11 @@ namespace Parcel.CoreEngine.Service.Interpretation
                         // Remark: notice the addition of this step could potentially make reflection based interpretative execution significantly slower
 
                         // Automatic conversion of number values
-                        if (nonOutMethodParameterValues[current] != null && nonOutMethodParameterValues[current].GetType() != item.ParameterType && TypeDescriptor.GetConverter(nonOutMethodParameterValues[current].GetType()).CanConvertTo(item.ParameterType)) // Requires IConvertible
-                            methodExpectedParameterValuesArray[i] = Convert.ChangeType(nonOutMethodParameterValues[current], item.ParameterType);
+                        if (nonOutMethodParameterValues[current] != null && nonOutMethodParameterValues[current].GetType() != item.ParameterType)
+                        {
+                            if (TypeHelper.TryConvert(nonOutMethodParameterValues[current], item.ParameterType, out object? result))
+                                methodExpectedParameterValuesArray[i] = result;
+                        }
                         else
                             methodExpectedParameterValuesArray[i] = nonOutMethodParameterValues[current];
                         current++;

--- a/Parcel.NExT/CoreEngines/Parcel.NExT.Interpreter/Types/FunctionalNodeDescription.cs
+++ b/Parcel.NExT/CoreEngines/Parcel.NExT.Interpreter/Types/FunctionalNodeDescription.cs
@@ -54,6 +54,8 @@ namespace Parcel.CoreEngine.Service.Interpretation
                     }
                     else
                     {
+                        // Remark: notice the addition of this step could potentially make reflection based interpretative execution significantly slower
+
                         // Automatic conversion of number values
                         if (nonOutMethodParameterValues[current] != null && nonOutMethodParameterValues[current].GetType() != item.ParameterType && TypeDescriptor.GetConverter(nonOutMethodParameterValues[current].GetType()).CanConvertTo(item.ParameterType)) // Requires IConvertible
                             methodExpectedParameterValuesArray[i] = Convert.ChangeType(nonOutMethodParameterValues[current], item.ParameterType);


### PR DESCRIPTION
> Obvious and semantically intuitive types should just convert themselves behind the scene.

Enhanced auto conversion between and from primitive types (including string) and implemented auto conversion using implicit operators.

Notice at the moment specifically with array type arguments, one might still encounter exception related to array coercion implementation - but that's not an issue with auto conversion per se so not fixed in this PR.


https://github.com/user-attachments/assets/26ea82e1-cf44-4def-8498-f79d97470ea1

